### PR TITLE
build: add release workflow

### DIFF
--- a/.github/release.md
+++ b/.github/release.md
@@ -1,0 +1,2 @@
+# Release notes
+<!-- This is a file used to write release notes -->

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -21,14 +21,14 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-20.04, ubuntu-22.04]
 
     runs-on: ${{ matrix.os }}
 
     steps:
       - name: Run the AppImage script
         run: |
-          curl "https://raw.githubusercontent.com/Crystalsage/install/test/appimage-scripts/AppImage_FLINT_Build.sh" | bash  
+          curl "https://raw.githubusercontent.com/moja-global/install/main/appimage-scripts/AppImage_FLINT_Build.sh" | bash  
           mv /home/runner/tmp/FLINT/Source/build/FLINT-*.AppImage /home/runner/FLINT-${{ matrix.os }}.AppImage
       - name: Cache artifacts
         uses: actions/cache@v3
@@ -42,7 +42,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-20.04, ubuntu-22.04]
 
     runs-on: ${{ matrix.os }}
 
@@ -58,12 +58,12 @@ jobs:
           echo "All AppImages have been built successfully."
           /home/runner/FLINT-${{ matrix.os }}.AppImage --appimage-extract
           cd squashfs-root
-          curl "https://raw.githubusercontent.com/Crystalsage/install/test/appimage-scripts/test-appimage-artifacts.sh" | bash
+          curl "https://raw.githubusercontent.com/moja-global/install/main/appimage-scripts/test-appimage-artifacts.sh" | bash
   release:
     needs: [build, test]
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-20.04, ubuntu-22.04]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -1,0 +1,81 @@
+name: Build FLINT AppImage
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Clone and run the AppImage script
+        run: |
+          git clone https://github.com/ankitaS11/AppImageDataForFlint
+          cd AppImageDataForFlint
+          chmod +x ./AppImage_FLINT_Build.sh
+          ./AppImage_FLINT_Build.sh
+          mv /home/runner/tmp/FLINT/Source/build/FLINT-*.AppImage /home/runner/FLINT-${{ matrix.os }}.AppImage
+
+      - name: Cache artifacts
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-appimages
+        with:
+          path: /home/runner/FLINT-${{ matrix.os }}.AppImage
+          key: ${{ matrix.os }}-appimage
+
+  test:
+    needs: build
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/cache@v3
+        with:
+          path: /home/runner/FLINT-${{ matrix.os }}.AppImage
+          key: ${{ matrix.os }}-appimage
+          
+      - name: Test AppImages
+        run: |
+          test -f "/home/runner/FLINT-${{ matrix.os }}.AppImage"; 
+          echo "All AppImages have been built successfully."
+
+          /home/runner/FLINT-${{ matrix.os }}.AppImage --appimage-extract
+          cd squashfs-root
+          wget "https://raw.githubusercontent.com/Crystalsage/github-releases-tests/main/test-appimage-artifacts.sh"
+          chmod +x test-appimage-artifacts.sh
+          ./test-appimage-artifacts.sh
+
+
+  release:
+    needs: [build, test]
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@master
+
+      - uses: actions/cache@v3
+        with:
+          path: /home/runner/FLINT-${{ matrix.os }}.AppImage
+          key: ${{ matrix.os }}-appimage
+
+      - name: Create release
+        uses: ncipollo/release-action@v1
+        with: 
+          allowUpdates: true
+          bodyfile: .github/release.md
+          prerelease: False
+          artifacts: "/home/runner/FLINT-*.AppImage"
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -1,8 +1,21 @@
+# A CI pipeline to release FLINT AppImages.
+#
+# Important: Some releases use custom, static tags like "dev" and "production".
+# If any branches with exact names are created, the CI fails due to ref 
+# resolution.
 name: Build FLINT AppImage
 on:
   push:
     tags:
       - 'v*'
+
+  workflow_dispatch:
+    inputs:
+      devRelease:
+        description: "Is this a dev release?"
+        default: true
+        required: true
+        type: boolean
 
 jobs:
   build:
@@ -13,14 +26,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Clone and run the AppImage script
+      - name: Run the AppImage script
         run: |
-          git clone https://github.com/ankitaS11/AppImageDataForFlint
-          cd AppImageDataForFlint
-          chmod +x ./AppImage_FLINT_Build.sh
-          ./AppImage_FLINT_Build.sh
+          curl "https://raw.githubusercontent.com/Crystalsage/install/test/appimage-scripts/AppImage_FLINT_Build.sh" | bash  
           mv /home/runner/tmp/FLINT/Source/build/FLINT-*.AppImage /home/runner/FLINT-${{ matrix.os }}.AppImage
-
       - name: Cache artifacts
         uses: actions/cache@v3
         env:
@@ -47,14 +56,9 @@ jobs:
         run: |
           test -f "/home/runner/FLINT-${{ matrix.os }}.AppImage"; 
           echo "All AppImages have been built successfully."
-
           /home/runner/FLINT-${{ matrix.os }}.AppImage --appimage-extract
           cd squashfs-root
-          wget "https://raw.githubusercontent.com/Crystalsage/github-releases-tests/main/test-appimage-artifacts.sh"
-          chmod +x test-appimage-artifacts.sh
-          ./test-appimage-artifacts.sh
-
-
+          curl "https://raw.githubusercontent.com/Crystalsage/install/test/appimage-scripts/test-appimage-artifacts.sh" | bash
   release:
     needs: [build, test]
     strategy:
@@ -71,7 +75,32 @@ jobs:
           path: /home/runner/FLINT-${{ matrix.os }}.AppImage
           key: ${{ matrix.os }}-appimage
 
-      - name: Create release
+      - name: Create dev release
+        if: ${{ inputs.devRelease }}
+        uses: ncipollo/release-action@v1
+        with: 
+          allowUpdates: true
+          name: "Dev release"
+          tag: "dev"
+          prerelease: False
+          artifacts: "/home/runner/FLINT-*.AppImage"
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      # This is because releases _need_ a tag. 
+      # Please change the tag later by pushing one.
+      - name: Create production release for manual run
+        if: ${{ (!inputs.devRelease) && (startsWith(github.ref_type, 'branch')) }}
+        uses: ncipollo/release-action@v1
+        with: 
+          allowUpdates: true
+          bodyfile: .github/release.md
+          tag: "production"
+          prerelease: False
+          artifacts: "/home/runner/FLINT-*.AppImage"
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create production release with a tag
+        if: ${{ (!inputs.devRelease) && (startsWith(github.ref_type, 'tag')) }}
         uses: ncipollo/release-action@v1
         with: 
           allowUpdates: true

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -26,10 +26,15 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Checkout the install repo
+        uses: actions/checkout@v3
+
       - name: Run the AppImage script
         run: |
-          curl "https://raw.githubusercontent.com/moja-global/install/main/appimage-scripts/AppImage_FLINT_Build.sh" | bash  
+          chmod +x $GITHUB_WORKSPACE/appimage-scripts/AppImage_FLINT_Build.sh
+          $GITHUB_WORKSPACE/appimage-scripts/AppImage_FLINT_Build.sh
           mv /home/runner/tmp/FLINT/Source/build/FLINT-*.AppImage /home/runner/FLINT-${{ matrix.os }}.AppImage
+
       - name: Cache artifacts
         uses: actions/cache@v3
         env:
@@ -47,6 +52,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Checkout the install repo
+        uses: actions/checkout@v3
+
       - uses: actions/cache@v3
         with:
           path: /home/runner/FLINT-${{ matrix.os }}.AppImage
@@ -58,7 +66,10 @@ jobs:
           echo "All AppImages have been built successfully."
           /home/runner/FLINT-${{ matrix.os }}.AppImage --appimage-extract
           cd squashfs-root
-          curl "https://raw.githubusercontent.com/moja-global/install/main/appimage-scripts/test-appimage-artifacts.sh" | bash
+          cp $GITHUB_WORKSPACE/appimage-scripts/test-appimage-artifacts.sh .
+          chmod +x ./test-appimage-artifacts.sh
+          ./test-appimage-artifacts.sh
+
   release:
     needs: [build, test]
     strategy:

--- a/appimage-scripts/AppImage_FLINT_Build.sh
+++ b/appimage-scripts/AppImage_FLINT_Build.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# Author: Ankita Sharma (https://github.com/ankitaS11)
+# This script is to faciliate building an AppImage for the FLINT repository
+# The AppImage built using this script has been, so far, tested on Ubuntu 22.04 derivatives.
+
+sudo apt -y update && sudo apt -y upgrade
+sudo apt -y install build-essential
+sudo apt -y install libfuse2
+
+WORKDIR=/home/$USER/tmp
+mkdir -p $WORKDIR
+
+# Remove existing versions of CMake (if any)
+sudo apt purge cmake
+
+# CMake needs OpenSSL (1.1.1o is the preferred versionas of June 2022)
+wget https://www.openssl.org/source/openssl-1.1.1o.tar.gz && \
+	tar -xvf openssl-1.1.1o.tar.gz && \
+	cd openssl-1.1.1o && \
+	./config && \
+	make && \
+	sudo make install
+
+# Install latest CMake version - sudo apt install cmake is outdated!!
+wget https://github.com/Kitware/CMake/releases/download/v3.24.0-rc1/cmake-3.24.0-rc1.tar.gz && \
+	tar -xvf cmake-3.24.0-rc1.tar.gz && \
+	cd cmake-3.24.0-rc1 && ./bootstrap && make && sudo make install
+
+# Install SQLite3
+sudo apt-get -y install libsqlite3-dev libsqlite3-0 sqlite3
+
+# Install Boost
+sudo apt-get -y install libboost-all-dev
+
+# Build Turtle from source
+cd $WORKDIR && git clone https://www.github.com/mat007/turtle.git && cd turtle && mkdir -p build && cd build && cmake .. && make && sudo make install
+
+# Install unixODBC
+cd $WORKDIR && wget http://www.unixodbc.org/unixODBC-2.3.11.tar.gz && gunzip unixODBC-2.3.11.tar.gz && tar xvf unixODBC*.tar
+cd $WORKDIR && cd unixODBC-2.3.11 && ./configure && make && sudo make install
+
+# Install sqlite3
+sudo apt -y install libsqlite3-dev
+sudo apt -y install libpcre3-dev
+
+# Install POCO
+cd $WORKDIR && wget https://github.com/pocoproject/poco/archive/refs/tags/poco-1.11.1-release.tar.gz --no-check-certificate && tar xvf poco-*.tar.gz
+
+cd $WORKDIR && cd poco-poco-1.11.1-release && mkdir -p cmake-build && cd cmake-build && \
+	cmake -DCMAKE_BUILD_TYPE=RELEASE -DPOCO_UNBUNDLED=ON \
+        -DENABLE_JSON=ON \
+        -DENABLE_DATA=ON \
+        -DENABLE_DATA_ODBC=ON \
+        -DENABLE_DATA_SQLITE=ON \
+        -DENABLE_DATA_MYSQL=OFF \
+        -DENABLE_ACTIVERECORD=OFF \
+        -DENABLE_ACTIVERECORD_COMPILER=OFF \
+        -DENABLE_ENCODINGS=OFF \
+        -DENABLE_ENCODINGS_COMPILER=OFF \
+        -DENABLE_XML=OFF \
+        -DENABLE_MONGODB=OFF \
+        -DENABLE_REDIS=OFF \
+        -DENABLE_PDF=OFF \
+        -DENABLE_UTIL=OFF \
+        -DENABLE_NET=OFF \
+        -DENABLE_NETSSL=OFF \
+        -DENABLE_CRYPTO=OFF \
+        -DENABLE_SEVENZIP=OFF \
+        -DENABLE_ZIP=OFF \
+        -DENABLE_PAGECOMPILER=OFF \
+        -DENABLE_PAGECOMPILER_FILE2PAGE=OFF .. && make && sudo make install
+
+# This should be changed to moja-global/FLINT.git once this PR (https://github.com/moja-global/FLINT/pull/119)
+# is merged.
+cd $WORKDIR && git clone https://www.github.com/ankitaS11/FLINT.git && cd FLINT && git checkout fix_poco_include && cd Source && mkdir -p build && cd build && \
+	cmake .. && make && make install DESTDIR=AppDir
+
+# Install linuxdeploy
+cd $WORKDIR/FLINT/Source/build/ && \
+	wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage --no-check-certificate && \
+	chmod +x linuxdeploy-x86_64.AppImage
+
+# Make sure you are in the build folder of the FLINT/Source/
+# This command will fail first (and it's expected)
+cd $WORKDIR/FLINT/Source/build/ && ./linuxdeploy-x86_64.AppImage --appdir AppDir || true
+
+# Copy the files from the GitHub repository:
+cd $WORKDIR/FLINT/Source/build && git clone https://www.github.com/ankitaS11/AppImageDataForFlint.git && cd AppImageDataForFlint && \
+	cp icon.png $WORKDIR/FLINT/Source/build/AppDir && \
+	cp usr/share/applications/AppDir.desktop $WORKDIR/FLINT/Source/build/AppDir/usr/share/applications/ && \
+	cd $WORKDIR/FLINT/Source/build && \
+	cp bin/* AppDir/usr/bin/ && \
+	./linuxdeploy-x86_64.AppImage --appdir AppDir --output appimage -i AppDir/icon.png

--- a/appimage-scripts/test-appimage-artifacts.sh
+++ b/appimage-scripts/test-appimage-artifacts.sh
@@ -1,0 +1,12 @@
+# Check if essential AppImages files have been bundled correctly
+function check_files() {
+	[ -s AppDir.desktop ] && echo "[OK] Desktop file exists" || exit 1
+	[ -s icon.png ] && echo "[OK] Icon file exists" || exit 1
+}
+
+function run_flint_test_binaries() {
+	./usr/bin/moja.cli &>/dev/null && echo "[OK] moja.cli" || echo "[ERR] moja.cli"
+}
+
+check_files
+run_flint_test_binaries


### PR DESCRIPTION
This PR adds a workflow for releasing FLINT Appimages for Ubuntu 18.04, 20.04 and 22.04.